### PR TITLE
Add form for test fund requests

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/get-test-funds.yml
+++ b/.github/DISCUSSION_TEMPLATE/get-test-funds.yml
@@ -5,13 +5,9 @@ body:
       value: |
         ## Test Fund Request
         ##
-        Here you may request funds from Entropy for use with the
-        Entropy TestNet. You will need an entropy account and the account's address to
-        make this request. Accounts can be created using our cli. Follow our
-        [Quicktart Guide](https://docs.entropy.xyz/) to get started.
+        Here you may request funds from Entropy for use with the Entropy test network (testnet). You must have an entropy account to make this request. Accounts can be created using the Entropy CLI. [Follow the quickstart guide for more information](https://docs.entropy.xyz/).
 
-        By default, you will be funded 10,000 test funds. If you need more,
-        please specify why in the request.
+        By default, you will be funded 10,000 test funds. If you need more, please specify why your the request.
 
   - type: input
     id: address

--- a/.github/DISCUSSION_TEMPLATE/get-test-funds.yml
+++ b/.github/DISCUSSION_TEMPLATE/get-test-funds.yml
@@ -17,7 +17,7 @@ body:
     id: address
     attributes:
       label: Entropy address
-      description: What is your entropy address?  This can be found with the cli and going to Manage Accounts > List Accounts and finding the "address" value in your chosen account.
+      description: The Entropy address that you want to send test funds to.
       validations:
         required: true
 

--- a/.github/DISCUSSION_TEMPLATE/get-test-funds.yml
+++ b/.github/DISCUSSION_TEMPLATE/get-test-funds.yml
@@ -7,7 +7,7 @@ body:
         ##
         Here you may request funds from Entropy for use with the Entropy test network (testnet). You must have an entropy account to make this request. Accounts can be created using the Entropy CLI. [Follow the quickstart guide for more information](https://docs.entropy.xyz/).
 
-        By default, you will be funded 10,000 test funds. If you need more, please specify why your the request.
+        By default, you will be funded 10,000 test funds. If you need more, please specify why in your request.
 
   - type: input
     id: address

--- a/.github/DISCUSSION_TEMPLATE/get-test-funds.yml
+++ b/.github/DISCUSSION_TEMPLATE/get-test-funds.yml
@@ -1,0 +1,47 @@
+title: "Fund Request"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Test Fund Request
+        ##
+        Here you may request funds from Entropy for use with the
+        Entropy TestNet. You will need an entropy account and the account's address to
+        make this request. Accounts can be created using our cli. Follow our
+        [Quicktart Guide](https://docs.entropy.xyz/) to get started.
+
+        By default, you will be funded 10,000 test funds. If you need more,
+        please specify why in the request.
+
+  - type: input
+    id: address
+    attributes:
+      label: Entropy address
+      description: What is your entropy address?  This can be found with the cli and going to Manage Accounts > List Accounts and finding the "address" value in your chosen account.
+      validations:
+        required: true
+
+  - input: dropdown
+    id: require-more-funds
+    attributes:
+      label: Do you require more than 10,000 test funds?
+      options:
+        - Yes
+        - No
+      default: 1
+
+  - input: textarea
+    id: fund-request-reason
+    attributes:
+      label: If you selected yes above, please tell us why
+      description: Please provide the context and reason for any fund request above the standard 10,000.
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Thanks
+
+        Upon submission, someone from Entropy will send the funds to your
+        address. This usually takes a couple of hours, but may take more.
+
+        Thanks!


### PR DESCRIPTION
Github discussions allows for [category
forms](https://docs.github.com/en/discussions/managing-discussions-for-your-community/creating-discussion-category-forms#creating-discussion-category-forms) that can be helpful when we are requesting the same info for each discussion point.  This commit adds an example for the test fund requests, using the [QuickStart Guide](https://docs.entropy.xyz) as the basis for its structure.  This would deviate from the guide in that the title of the discussion is set automatically to "Test Fund" (though this could be changed), and the submitter puts their address in the first input field of the form.